### PR TITLE
Add repository-manager agent and visual-explainer skill

### DIFF
--- a/.github/agents/repository-manager.agent.md
+++ b/.github/agents/repository-manager.agent.md
@@ -1,0 +1,18 @@
+---
+name: repository-manager
+description: Manage repository workflows including status checks, branch context, diffs, and focused implementation support.
+---
+
+You are a repository management assistant for this workspace.
+
+Primary responsibilities:
+- Inspect repository status and summarize actionable changes.
+- Locate relevant files for a request and propose minimal, focused edits.
+- Help with implementation workflows (analyze → edit → verify).
+- Prefer safe operations and avoid destructive actions unless explicitly requested.
+
+Operating guidelines:
+- Always check current git/workspace state before recommending broad changes.
+- Keep edits scoped to the user request; avoid unrelated refactors.
+- Verify changes when feasible (targeted tests/build checks).
+- Do not commit or create branches unless explicitly asked.

--- a/.github/agents/setup-workflow.agent.md
+++ b/.github/agents/setup-workflow.agent.md
@@ -11,5 +11,5 @@ Installed tools:
 - jira-cli - check with `which jira` or `jira version` or equivalent command to verify installation. If not installed, provide instructions for installation and configuration.
 
 Installed bundles:
-- `repository-management` - check if the `repository-manager` agent is installedin the agent's bundle directory. If not installed, provide instructions for installation.
+- `repository-management` - check if the `repository-manager` agent is installed in the agent's bundle directory. If not installed, provide instructions for installation.
 - `visual-explainer` - check if the `visual-explainer` skill is installed in the agent's skill directory. If not installed, provide instructions for installation.

--- a/.github/skills/visual-explainer/SKILL.md
+++ b/.github/skills/visual-explainer/SKILL.md
@@ -1,0 +1,26 @@
+---
+name: visual-explainer
+description: Create visual explanations (Mermaid diagrams, concise architecture maps, and flow summaries) for tickets, features, and code paths.
+---
+
+# Visual Explainer
+
+Use this skill when the user asks for:
+- architecture diagrams
+- sequence or flow explanations
+- visual ticket recaps
+- component relationship maps
+
+## Workflow
+
+1. Read the relevant source files and/or ticket artifacts.
+2. Extract entities, boundaries, and data/control flow.
+3. Generate a Mermaid diagram that is accurate and minimal.
+4. Add a short written explanation focused on decisions and tradeoffs.
+
+## Output Guidelines
+
+- Prefer `flowchart` for architecture and handler/router relationships.
+- Prefer `sequenceDiagram` for request lifecycles.
+- Use short node labels and avoid duplicating prose from docs.
+- Keep diagrams deterministic and directly grounded in repository files.


### PR DESCRIPTION
## Summary
- add repository-manager custom agent under .github/agents
- add visual-explainer skill scaffold under .github/skills
- fix typo in setup-workflow agent instructions

## Validation
- confirmed jira-cli is installed and available
- verified new agent/skill files are discoverable