### PR TITLE
KAN-10 Add on-merge Jira joke workflow

### DIFF
--- a/.github/workflows/jira-joke-readonly.workflow.lock
+++ b/.github/workflows/jira-joke-readonly.workflow.lock
@@ -1,0 +1,7 @@
+version: 1
+workflow: .github/workflows/jira-joke-readonly.workflow.md
+integrity:
+  on: [pull-request:merged]
+  permissions: [contents:read, issues:read, pull-requests:read]
+  tools: [github, jira]
+  safe-outputs: [jira-comment]

--- a/.github/workflows/jira-joke-readonly.workflow.md
+++ b/.github/workflows/jira-joke-readonly.workflow.md
@@ -1,0 +1,44 @@
+---
+on:
+  pull-request:
+    merged: true
+
+permissions:
+  contents: read
+  issues: read
+  pull-requests: read
+
+safe-outputs:
+  jira-comment:
+    body-prefix: "Jira joke: "
+
+tools:
+  github:
+  jira:
+---
+
+# Jira Joke Publisher (Read-Only Repo Access)
+
+On PR merge, generate a short, work-safe joke about Jira and publish it to the Jira ticket referenced by that PR.
+
+## Ticket Resolution
+- Resolve Jira ticket key from the merged PR context, in this order:
+  1. PR title
+  2. PR branch name
+  3. PR body
+- Ticket key format: `ABC-123`
+- If no ticket key is found, do nothing and report no-op.
+
+## Requirements
+- Keep repository access read-only.
+- Do not create, edit, rename, or delete repository files.
+- Do not run git write operations.
+- Joke must be friendly and professional.
+
+## Steps
+1. Confirm Jira CLI is available and authenticated.
+2. Resolve the ticket key from merged PR context.
+3. Generate one concise Jira joke.
+4. Publish comment:
+  - `jira issue comment add <resolved-ticket> "Jira joke: <joke>"`
+5. Report success with resolved ticket key and posted joke.


### PR DESCRIPTION
## Summary
- add agentic workflow spec to post a Jira joke when a PR merges
- trigger on merged pull request events
- resolve ticket key from PR title/branch/body
- enforce read-only repo permissions in workflow frontmatter
- add corresponding workflow lock file

## Files
- .github/workflows/jira-joke-readonly.workflow.md
- .github/workflows/jira-joke-readonly.workflow.lock